### PR TITLE
11 FR | Quitar estable de la lista de estados al ingreso

### DIFF
--- a/src/app/components/create-visit.tsx
+++ b/src/app/components/create-visit.tsx
@@ -34,7 +34,6 @@ const patientStatuses = [
   { value: 'conscious', label: 'Consciente' },
   { value: 'unconscious', label: 'Inconsciente' },
   { value: 'in_danger', label: 'En Peligro' },
-  { value: 'stable', label: 'Estable' },
   { value: 'critical', label: 'Crítico' }
 ]
 


### PR DESCRIPTION
quitado el estado estable de la lista de estados del paciente al ingreso por redundancia y solapamiento con tros estados
